### PR TITLE
Fix crash in really short data blocks

### DIFF
--- a/src/tape.rs
+++ b/src/tape.rs
@@ -52,7 +52,7 @@ impl Block {
     /// this pattern, `false` otherwise.
     pub fn is_bin_header(&self) -> bool {
         let data = self.data_without_prefix();
-        data[..10] == [0xd0, 0xd0, 0xd0, 0xd0, 0xd0, 0xd0, 0xd0, 0xd0, 0xd0, 0xd0]
+        data.len() >= 10 && data[..10] == [0xd0, 0xd0, 0xd0, 0xd0, 0xd0, 0xd0, 0xd0, 0xd0, 0xd0, 0xd0]
     }
 
     /// Returns `true` if the block is detected as a Basic header.
@@ -62,7 +62,7 @@ impl Block {
     /// this pattern, `false` otherwise.
     pub fn is_basic_header(&self) -> bool {
         let data = self.data_without_prefix();
-        data[..10] == [0xd3, 0xd3, 0xd3, 0xd3, 0xd3, 0xd3, 0xd3, 0xd3, 0xd3, 0xd3]
+        data.len() >= 10 && data[..10] == [0xd3, 0xd3, 0xd3, 0xd3, 0xd3, 0xd3, 0xd3, 0xd3, 0xd3, 0xd3]
     }
 
     /// Returns `true` if the block is detected as an ASCII header.
@@ -72,7 +72,7 @@ impl Block {
     /// this pattern, `false` otherwise.
     pub fn is_ascii_header(&self) -> bool {
         let data = self.data_without_prefix();
-        data[..10] == [0xea, 0xea, 0xea, 0xea, 0xea, 0xea, 0xea, 0xea, 0xea, 0xea]
+        data.len() >= 10 && data[..10] == [0xea, 0xea, 0xea, 0xea, 0xea, 0xea, 0xea, 0xea, 0xea, 0xea]
     }
 
     /// Returns `true` if the block is detected as a file header (either bin, basic or ascii).


### PR DESCRIPTION
Tool crashes when block is shorter than 10 bytes with the following error:

> thread 'main' panicked at 'range end index 10 out of range for slice of length 8', src/tape.rs:55:9

Add sanity check prior to array comparison.

Issue seen when analyzing the cas file for "Auf Wiedersehen Monty".